### PR TITLE
Don't use require in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
-require: rubocop-rspec
-
 AllCops:
   DisplayCopNames: true
   Include:


### PR DESCRIPTION
Rubocop no longer uses the `require:` syntax in its config file. Running `bundle exec rake rubocop` will require `rubocop-rspec`.
