### PR TITLE
Extracting #share_notified? behavior

### DIFF
--- a/lib/share_notify.rb
+++ b/lib/share_notify.rb
@@ -8,6 +8,7 @@ module ShareNotify
   autoload :Metadata,       'share_notify/metadata'
   autoload :PushDocument,   'share_notify/push_document'
   autoload :SearchResponse, 'share_notify/search_response'
+  autoload :NotificationQueryService, 'share_notify/notification_query_service'
 
   class << self
     def configure(value)

--- a/lib/share_notify/exceptions.rb
+++ b/lib/share_notify/exceptions.rb
@@ -1,0 +1,10 @@
+module ShareNotify
+  class RuntimeError < ::RuntimeError
+  end
+
+  class InitializationError < RuntimeError
+    def initialize(context, method_names)
+      super("Expected #{context.inspect} to respond to #{method_names.inspect}")
+    end
+  end
+end

--- a/lib/share_notify/metadata.rb
+++ b/lib/share_notify/metadata.rb
@@ -1,26 +1,17 @@
 # Queries the SHARE search api for an existing record. This assumes the class into which this
 # module is included responds to #url and that in turn is mapped to the docID of the Share
 # document that was originally uploaded via the SHARE push API.
+#
+# @see ShareNotify::NotificationQueryService for details of interface expectations
 module ShareNotify::Metadata
   extend ActiveSupport::Concern
+  extend Forwardable
 
-  def share_notified?
-    return if response.status != 200
-    return false if response.count < 1
-    response.docs.first.doc_id == url
-  end
-
-  def call
-    api.search("shareProperties.docID:\"#{url}\"")
-  end
+  def_delegator :notification_query_service, :share_notified?
 
   private
 
-    def response
-      @response ||= ShareNotify::SearchResponse.new(call)
-    end
-
-    def api
-      @api ||= ShareNotify::API.new
+    def notification_query_service
+      @notification_query_service ||= ShareNotify::NotificationQueryService.new(self)
     end
 end

--- a/lib/share_notify/notification_query_service.rb
+++ b/lib/share_notify/notification_query_service.rb
@@ -1,0 +1,38 @@
+require 'share_notify/exceptions'
+
+module ShareNotify
+  # Queries the SHARE search api for an existing record. This assumes the class into which this
+  # module is included responds to #url and that in turn is mapped to the docID of the Share
+  # document that was originally uploaded via the SHARE push API.
+  #
+  # @see ShareNotify::PushDocument
+  class NotificationQueryService
+    def initialize(context)
+      self.context = context
+    end
+
+    def share_notified?
+      response = search("shareProperties.docID:\"#{context.url}\"")
+      return if response.status != 200
+      return false if response.count < 1
+      response.docs.first.doc_id == context.url
+    end
+
+    private
+
+      def search(string)
+        ShareNotify::SearchResponse.new(api.search(string))
+      end
+
+      def api
+        ShareNotify::API.new
+      end
+
+      attr_reader :context
+
+      def context=(input)
+        raise ShareNotify::InitializationError.new(input, [:url]) unless input.respond_to?(:url)
+        @context = input
+      end
+  end
+end

--- a/spec/lib/share_notify/notification_query_service_spec.rb
+++ b/spec/lib/share_notify/notification_query_service_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'share_notify/notification_query_service'
+require 'support/vcr'
+
+RSpec.describe ShareNotify::NotificationQueryService do
+  it 'fails to initialize if the given context does not respond to #url' do
+    object = double
+    expect { described_class.new(object) }.to raise_error(ShareNotify::InitializationError)
+  end
+
+  context '#share_notified?' do
+    before { WebMock.enable! }
+    after { WebMock.disable! }
+    it 'is true when object is already in SHARE' do
+      object = double('Share-able OBJECT', url: 'http://example.com/document1')
+      subject = described_class.new(object)
+      VCR.use_cassette('share_metadata', record: :none) do
+        expect(subject).to be_share_notified
+      end
+    end
+    it 'is false when object is not in SHARE' do
+      object = double('Share-able OBJECT', url: 'http://example.com/bogusDoc')
+      subject = described_class.new(object)
+      VCR.use_cassette('share_metadata', record: :none) do
+        expect(subject).not_to be_share_notified
+      end
+    end
+  end
+end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -5,35 +5,16 @@ describe ShareNotify::Metadata do
   before(:all) do
     class MockObject
       include ShareNotify::Metadata
+      attr_reader :url
     end
   end
 
   after(:all) { Object.send(:remove_const, :MockObject) if defined?(MockObject) }
 
-  before { WebMock.enable! }
-  after { WebMock.disable! }
-
   let(:object) { MockObject.new }
 
-  describe '#share_notified?' do
-    subject { object.share_notified? }
-    context 'when object is already in SHARE' do
-      let(:url) { 'http://example.com/document1' }
-      before { allow(object).to receive(:url).and_return(url) }
-      specify do
-        VCR.use_cassette('share_metadata', record: :none) do
-          is_expected.to be true
-        end
-      end
-    end
-    context 'when object is not in SHARE' do
-      let(:url) { 'http://example.com/bogusDoc' }
-      before { allow(object).to receive(:url).and_return(url) }
-      specify do
-        VCR.use_cassette('share_metadata', record: :none) do
-          is_expected.to be false
-        end
-      end
-    end
+  it 'will delegate #share_notified? to the underlying NotificationQueryService' do
+    expect(object.send(:notification_query_service)).to receive(:share_notified?)
+    object.share_notified?
   end
 end


### PR DESCRIPTION
This pull request provides more explicit logic guarding the interface
expectations of the `#share_notified?` method. In other words, by
leveraging a collaborating class, we can instantiate that class and
enforce the expected behavior.

Also, instead of mixing in multiple methods, in particular one that was
named `#call`, I am preferring to instead mix in a smaller number of
methods.
