### PR TITLE
Enabling deletion of documents from SHARE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in share_notify.gemspec
 gemspec
 
-gem 'byebug'
+gem 'byebug', require: false
 gem 'rubocop', require: false
 # Removed until https://github.com/nevir/rubocop-rspec/issues/78 is resolved
 #gem 'rubocop-rspec', require: false

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Then send the document to Share using the `API` class:
     api = ShareNotify::API.new
     api.post(document.to_share.to_json)
 
+### Deleting Data
+
+Same as above, but adding an additional "delete" property informs the Share API that this
+document should be delete from the Search API:
+
+    >  document = ShareNotify::PushDocument.new("http://my.document.id/1234")
+    >  document.title = "Some Title"
+    >  document.add_contributor(name: "My Name", email: "myemail@example.com")
+    >  document.delete
+    >  api = ShareNotify::API.new
+    >  api.post(document.to_share.to_json)
+
 ### Querying
 
 You can query Share's Search API using the terms outlined in <https://osf.io/dajtq/wiki/SHARE%20Search>
@@ -71,7 +83,7 @@ if the document is already present in ShareNotify's Search API.
     => true
 
 Note: It may take 24 hours or more before documents that have been initially pushed to Share will appear
-in the Search API.
+in or be deleted from the Search API.
 
 ## Contributing
 

--- a/lib/share_notify/push_document.rb
+++ b/lib/share_notify/push_document.rb
@@ -1,6 +1,13 @@
 module ShareNotify
   class PushDocument
-    attr_reader :uris, :contributors, :providerUpdatedDateTime, :version, :publisher, :languages, :tags
+    attr_reader :uris,
+                :contributors,
+                :providerUpdatedDateTime,
+                :version,
+                :publisher,
+                :languages,
+                :tags,
+                :otherProperties
     attr_accessor :title, :description
 
     # @param [String] uri that identifies the resource
@@ -42,11 +49,13 @@ module ShareNotify
       @publisher = publisher
     end
 
+    # @param [Array<String>] languages list of languages
     def languages=(languages)
       return false unless languages.is_a?(Array)
       @languages = languages
     end
 
+    # @param [Array<String>] tags list of tags
     def tags=(tags)
       return false unless tags.is_a?(Array)
       @tags = tags
@@ -56,12 +65,25 @@ module ShareNotify
       { jsonData: self }
     end
 
+    def delete
+      @otherProperties = [OtherProperty.new("status", status: ["deleted"])]
+    end
+
     class ShareUri
       attr_reader :canonicalUri, :providerUris
 
       def initialize(uri)
         @canonicalUri = uri
         @providerUris = [uri]
+      end
+    end
+
+    class OtherProperty
+      attr_reader :name, :property
+
+      def initialize(*args)
+        @name = args.shift
+        @properties = args.shift
       end
     end
   end

--- a/share_notify.gemspec
+++ b/share_notify.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'httparty'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'factory_girl'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,34 @@
+FactoryGirl.define do
+  factory :document, class: ShareNotify::PushDocument do
+    uri "http://example.com/fake-uri"
+    initialize_with { new(uri) }
+
+    factory :document_with_datetime do
+      initialize_with { new(uri, DateTime.new(1990, 12, 12, 12, 12, 12, '+5')) }
+    end
+
+    factory :document_with_date do
+      initialize_with { new(uri, Date.today) }
+    end
+
+    factory :valid_document do
+      title 'Some title'
+      after(:build) { |d| d.add_contributor(name: 'Job', email: 'joe@joe.com') }
+    end
+
+    factory :share_document do
+      uri     'http://example.com/document1'
+      version 'someID'
+      title   'Interesting research'
+      updated DateTime.new(2014, 12, 12)
+      after(:build) do |d|
+        d.add_contributor(name: 'Roger Movies Ebert', email: 'rogerebert@example.com')
+        d.add_contributor(name: 'Roger Madness Ebert')
+      end
+
+      factory :delete_document do
+        after(:build, &:delete)
+      end
+    end
+  end
+end

--- a/spec/fixtures/share_delete.json
+++ b/spec/fixtures/share_delete.json
@@ -1,0 +1,23 @@
+{
+  "jsonData": {
+    "contributors": [
+      { "name": "Roger Movies Ebert", "email": "rogerebert@example.com" },
+      { "name": "Roger Madness Ebert"}
+    ],
+    "providerUpdatedDateTime": "2014-12-12T00:00:00Z",
+    "title": "Interesting research",
+    "version": { "versionId": "someID" },
+    "uris": {
+      "canonicalUri": "http://example.com/document1",
+      "providerUris": [ "http://example.com/document1" ]
+    },
+    "otherProperties": [
+      {
+        "name": "status",
+        "properties": {
+          "status": ["deleted"]
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/vcr_cassettes/share_notify_delete.yml
+++ b/spec/fixtures/vcr_cassettes/share_notify_delete.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://staging.osf.io/api/v1/share/data
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "jsonData": {
+            "contributors": [
+              { "name": "Roger Movies Ebert", "email": "rogerebert@example.com" },
+              { "name": "Roger Madness Ebert"}
+            ],
+            "providerUpdatedDateTime": "2014-12-12T00:00:00Z",
+            "title": "Interesting research",
+            "version": { "versionId": "someID" },
+            "uris": {
+              "canonicalUri": "http://example.com/document1",
+              "providerUris": [ "http://example.com/document1" ]
+            },
+            "otherProperties": [
+              {
+                "name": "status",
+                "properties": {
+                  "status": ["deleted"]
+                }
+              }
+            ]
+          }
+        }
+    headers:
+      Authorization:
+      - Token SECRET_TOKEN
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 23 Mar 2016 14:39:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+    body:
+      encoding: UTF-8
+      string: '{"id":1080,"updated":"2016-03-23T14:39:14.603181Z","docID":"http://example.com/document1","source":"scholarsphere","jsonData":{"contributors":[{"name":"Roger
+        Movies Ebert","email":"rogerebert@example.com"},{"name":"Roger Madness Ebert"}],"title":"Interesting
+        research","shareProperties":{"source":"scholarsphere","docID":"http://example.com/document1"},"otherProperties":[{"name":"status","properties":{"status":["deleted"]}}],"version":{"versionId":"someID"},"providerUpdatedDateTime":"2014-12-12T00:00:00Z","uris":{"canonicalUri":"http://example.com/document1","providerUris":["http://example.com/document1"]}},"status":"deleted"}'
+    http_version: 
+  recorded_at: Wed, 23 Mar 2016 14:39:14 GMT
+recorded_with: VCR 3.0.1

--- a/spec/push_document_spec.rb
+++ b/spec/push_document_spec.rb
@@ -5,7 +5,7 @@ describe ShareNotify::PushDocument do
 
   describe '#new' do
     context 'without @param datetime' do
-      subject { described_class.new(uri) }
+      subject { build(:document) }
       its(:contributors) { is_expected.to be_empty }
       its(:updated) { is_expected.not_to be_nil }
       its(:providerUpdatedDateTime) { is_expected.to eq(Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')) }
@@ -13,35 +13,18 @@ describe ShareNotify::PushDocument do
     end
 
     context 'with @param datetime which is time object' do
-      let(:d_date) { DateTime.new(1990, 12, 12, 12, 12, 12, '+5') }
-      subject { described_class.new(uri, d_date) }
+      subject { build(:document_with_datetime) }
       its(:providerUpdatedDateTime) { is_expected.to eq('1990-12-12T07:12:12Z') }
     end
 
     context 'with @param datetime which is not time object' do
-      let(:d_date) { Date.today }
-      subject { described_class.new(uri, d_date) }
+      subject { build(:document_with_date) }
       its(:providerUpdatedDateTime) { is_expected.to eq(Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')) }
     end
   end
 
-  describe '@providerUpdatedDateTime' do
-    subject do
-      valid = described_class.new(uri)
-      valid.add_contributor(name: 'Job', email: 'joe@joe.com')
-      valid.title = 'Some title'
-      valid
-    end
-    it { is_expected.to be_valid }
-  end
-
   describe 'a valid document' do
-    subject do
-      valid = described_class.new(uri)
-      valid.add_contributor(name: 'Job', email: 'joe@joe.com')
-      valid.title = 'Some title'
-      valid
-    end
+    subject { build(:valid_document) }
     it { is_expected.to be_valid }
   end
 
@@ -54,106 +37,68 @@ describe ShareNotify::PushDocument do
 
   describe '#updated=' do
     context 'with a DateTime' do
-      let(:date) { DateTime.new(1990, 12, 12, 12, 12, 12, '+5') }
-      subject do
-        valid = described_class.new(uri)
-        valid.updated = date
-        valid
-      end
+      subject { build(:document, updated: DateTime.new(1990, 12, 12, 12, 12, 12, '+5')) }
       its(:updated) { is_expected.to eq('1990-12-12T07:12:12Z') }
     end
   end
 
   describe '#version=' do
-    subject do
-      valid = described_class.new(uri)
-      valid.version = 'someID'
-      valid
-    end
+    subject { build(:document, version: 'someID') }
     its(:version) { is_expected.to eq(versionId: 'someID') }
   end
 
   describe '#description' do
-    subject do
-      obj = described_class.new(uri)
-      obj.description = 'some description'
-      obj
-    end
+    subject { build(:document, description: 'some description') }
     its(:description) { is_expected.to eq('some description') }
   end
 
   describe '#publisher' do
     context 'with a name' do
-      subject do
-        obj = described_class.new(uri)
-        obj.publisher = { name: 'myname', uri: 'http://example.com' }
-        obj
-      end
+      subject { build(:document, publisher: { name: 'myname', uri: 'http://example.com' }) }
       its(:publisher) { is_expected.to eq(name: 'myname', uri: 'http://example.com') }
     end
 
     context 'without a name' do
-      subject do
-        obj = described_class.new(uri)
-        obj.publisher = { uri: 'http://example.com' }
-        obj
-      end
+      subject { build(:document, publisher: { uri: 'http://example.com' }) }
       its(:publisher) { is_expected.to be_nil }
     end
   end
 
   describe '#languages' do
     context '@param is an array' do
-      subject do
-        obj = described_class.new(uri)
-        obj.languages = ['English']
-        obj
-      end
+      subject { build(:document, languages: ['English']) }
       its(:languages) { is_expected.to eq(['English']) }
     end
 
     context '@param is not an array' do
-      subject do
-        obj = described_class.new(uri)
-        obj.languages = 'English'
-        obj
-      end
+      subject { build(:document, languages: 'English') }
       its(:languages) { is_expected.to be_nil }
     end
   end
 
   describe '#tags' do
     context '@param is an array' do
-      subject do
-        obj = described_class.new(uri)
-        obj.tags = ['tag1', 'tag2']
-        obj
-      end
+      subject { build(:document, tags: ['tag1', 'tag2']) }
       its(:tags) { is_expected.to eq(['tag1', 'tag2']) }
     end
 
     context '@param is not an array' do
-      subject do
-        obj = described_class.new(uri)
-        obj.languages = 'tag1'
-        obj
-      end
+      subject { build(:document, tags: 'tag1') }
       its(:tags) { is_expected.to be_nil }
     end
   end
 
-  describe '#to_share' do
-    let(:example) do
-      doc = described_class.new('http://example.com/document1')
-      doc.version = 'someID'
-      doc.title = 'Interesting research'
-      doc.updated = DateTime.new(2014, 12, 12)
-      doc.add_contributor(name: 'Roger Movies Ebert', email: 'rogerebert@example.com')
-      doc.add_contributor(name: 'Roger Madness Ebert')
-      doc
-    end
-    let(:fixture) { JSON.parse(File.read(File.join(fixture_path, 'share.json'))) }
+  context 'with complete documents' do
     subject { JSON.parse(example.to_share.to_json) }
-    it { is_expected.to eq(fixture) }
+    describe '#to_share' do
+      let(:example) { build(:share_document) }
+      let(:fixture) { JSON.parse(File.read(File.join(fixture_path, 'share.json'))) }
+      it { is_expected.to eq(fixture) }
+    end
+    describe '#delete' do
+      let(:example) { build(:delete_document) }
+      let(:fixture) { JSON.parse(File.read(File.join(fixture_path, 'share_delete.json'))) }
+      it { is_expected.to eq(fixture) }
+    end
   end
 end

--- a/spec/share_notify_api_spec.rb
+++ b/spec/share_notify_api_spec.rb
@@ -21,11 +21,21 @@ describe ShareNotify::API do
   end
 
   describe '#post' do
-    let(:post_data) { File.read(File.join(fixture_path, 'share.json')) }
     subject { described_class.new.post(post_data) }
-    it 'is successful' do
-      VCR.use_cassette('share_notify', record: :none) do
-        expect(subject.code).to eq(201)
+    context 'when creating a new document' do
+      let(:post_data) { File.read(File.join(fixture_path, 'share.json')) }
+      it 'is successful' do
+        VCR.use_cassette('share_notify', record: :none) do
+          expect(subject.code).to eq(201)
+        end
+      end
+    end
+    context 'when deleting an existing document' do
+      let(:post_data) { File.read(File.join(fixture_path, 'share_delete.json')) }
+      it 'is successful' do
+        VCR.use_cassette('share_notify_delete', record: :none) do
+          expect(subject.code).to eq(201)
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,13 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'share_notify'
 require 'rspec/its'
+require 'byebug' unless ENV['TRAVIS']
+require 'factory_girl'
+require 'factories'
+
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end
 
 def fixture_path
   File.join(ShareNotify.root, 'spec', 'fixtures')


### PR DESCRIPTION
SHARE Notify recently added the ability to delete documents. The process involves POSTing the original document to SHARE again, but with an added set of metadata fields indicating the document should be removed.
