### PR TITLE
Removing rubocop-rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 
 gem 'byebug'
 gem 'rubocop', require: false
-gem 'rubocop-rspec', require: false
-
+# Removed until https://github.com/nevir/rubocop-rspec/issues/78 is resolved
+#gem 'rubocop-rspec', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Run style checker"
 RuboCop::RakeTask.new(:rubocop) do |task|
-  task.requires << 'rubocop-rspec'
+  # task.requires << 'rubocop-rspec'
   task.fail_on_error = true
 end
 


### PR DESCRIPTION
It isn't compatible with the last version of rspec
nevir/rubocop-rspec#78
