### PR TITLE
Adding code to hit the v2 node endpoint

### DIFF
--- a/lib/share_notify/api_v2.rb
+++ b/lib/share_notify/api_v2.rb
@@ -38,7 +38,7 @@ class ShareNotify::ApiV2
   private
 
     def api_data_point
-      '/api/v2/normalizeddata/'
+      ShareNotify.config.fetch('api_data_point', '/api/v2/normalizeddata/')
     end
 
     def api_search_point

--- a/lib/share_notify/push_document.rb
+++ b/lib/share_notify/push_document.rb
@@ -16,7 +16,8 @@ module ShareNotify
                   :description,
                   :type,
                   :date_published,
-                  :rights
+                  :rights,
+                  :category
 
     # @param [String] uri that identifies the resource
     def initialize(uri, datetime = nil)
@@ -87,6 +88,11 @@ module ShareNotify
     # return data formatted for V1 of the SHARE API.
     def to_share
       { jsonData: self }
+    end
+
+    #v2 json format
+    def to_json
+      "{\"data\": {\"type\": \"nodes\", \"attributes\": #{super}}}"
     end
 
     def delete

--- a/spec/fixtures/share_v2_node.json
+++ b/spec/fixtures/share_v2_node.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+   "attributes": {
+      "contributors": [
+        { "name": "Roger Movies Ebert", "email": "rogerebert@example.com" },
+        { "name": "Roger Madness Ebert"}
+      ],
+      "providerUpdatedDateTime": "2014-12-12T00:00:00Z",
+      "title": "Interesting research",
+      "version": { "versionId": "someID" },
+      "uris": {
+        "canonicalUri": "http://example.com/document1",
+        "providerUris": [ "http://example.com/document1" ]
+      }
+    },
+   "type": "nodes"
+  }
+}

--- a/spec/push_document_spec.rb
+++ b/spec/push_document_spec.rb
@@ -123,8 +123,13 @@ describe ShareNotify::PushDocument do
 
     context '@param is not a hash' do
       subject { build(:document, extra: 'funding notes') }
-      its(:languages) { is_expected.to be_nil }
+      its(:extra) { is_expected.to be_nil }
     end
+  end
+
+  describe '#category' do
+    subject { build(:document, category: 'other') }
+    its(:category) { is_expected.to eq('other') }
   end
 
   context 'with complete documents' do
@@ -137,6 +142,15 @@ describe ShareNotify::PushDocument do
     describe '#delete' do
       let(:example) { build(:delete_document) }
       let(:fixture) { JSON.parse(File.read(File.join(fixture_path, 'share_delete.json'))) }
+      it { is_expected.to eq(fixture) }
+    end
+  end
+
+  context '#to_json' do
+    subject { JSON.parse(example.to_json) }
+    describe '#to_share' do
+      let(:example) { build(:share_document) }
+      let(:fixture) { JSON.parse(File.read(File.join(fixture_path, 'share_v2_node.json'))) }
       it { is_expected.to eq(fixture) }
     end
   end


### PR DESCRIPTION
The normalizeddata endpoint seems to be obsolete and the node endopoint is available.  This does not remove the normalizeddata but allows the user to choose the api endpoint via configuration and produces the json needed to send to the node endpoint

Co-authored-by: Adam Wead <amsterdamos@gmail.com>